### PR TITLE
Make LruCache multiplatform (targeting JVM and Apple platforms)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.vanniktech.maven.publish") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         mavenCentral()
     }

--- a/lrucache/build.gradle.kts
+++ b/lrucache/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     kotlin("multiplatform")
 
@@ -14,12 +16,117 @@ kotlin {
         withJava()
     }
 
+    val appleConfig: KotlinNativeTarget.() -> Unit = {
+        binaries {
+            framework {
+                baseName = "lru-cache"
+            }
+        }
+    }
+
+    macosX64(appleConfig)
+    macosArm64(appleConfig)
+
+    ios(appleConfig)
+    iosArm32(appleConfig)
+    iosSimulatorArm64(appleConfig)
+
+    watchos(appleConfig)
+    watchosX86(appleConfig)
+    watchosSimulatorArm64(appleConfig)
+
+    tvos(appleConfig)
+    tvosSimulatorArm64(appleConfig)
+
     @Suppress("UNUSED_VARIABLE")
     sourceSets {
         val commonMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }
+        }
+
+        val commonTest by getting
+
+        val appleMain by creating {
+            dependsOn(commonMain)
+        }
+
+        val appleTest by creating {
+            dependsOn(commonTest)
+        }
+
+        val macosX64Main by getting
+        val macosArm64Main by getting
+        val macosMain by creating {
+            dependsOn(appleMain)
+
+            // There is no built-in macOS target shortcut
+            macosX64Main.dependsOn(this)
+            macosArm64Main.dependsOn(this)
+        }
+
+        val macosX64Test by getting
+        val macosArm64Test by getting
+        val macosTest by creating {
+            dependsOn(appleTest)
+
+            dependsOn(macosMain)
+            macosX64Test.dependsOn(this)
+            macosArm64Test.dependsOn(this)
+        }
+
+        val iosArm32Main by getting
+        val iosSimulatorArm64Main by getting
+        val iosMain by getting {
+            dependsOn(appleMain)
+
+            // iOS target shortcut only contains: iosArm64, iosX64
+            iosArm32Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
+        }
+
+        val iosArm32Test by getting
+        val iosSimulatorArm64Test by getting
+        val iosTest by getting {
+            dependsOn(appleTest)
+
+            iosArm32Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
+        }
+
+        val watchosX86Main by getting
+        val watchosSimulatorArm64Main by getting
+        val watchosMain by getting {
+            dependsOn(appleMain)
+
+            // watchOS target shortcut only contains: watchosArm32, watchosArm64, watchosX64
+            watchosX86Main.dependsOn(this)
+            watchosSimulatorArm64Main.dependsOn(this)
+        }
+
+        val watchosX86Test by getting
+        val watchosSimulatorArm64Test by getting
+        val watchosTest by getting {
+            dependsOn(appleTest)
+
+            watchosX86Test.dependsOn(this)
+            watchosSimulatorArm64Test.dependsOn(this)
+        }
+
+        val tvosSimulatorArm64Main by getting
+        val tvosMain by getting {
+            dependsOn(appleMain)
+
+            // tvOS target shortcut only contains: tvosArm64, tvosX64
+            tvosSimulatorArm64Main.dependsOn(this)
+        }
+
+        val tvosSimulatorArm64Test by getting
+        val tvosTest by getting {
+            dependsOn(appleTest)
+
+            tvosSimulatorArm64Test.dependsOn(this)
         }
     }
 }

--- a/lrucache/build.gradle.kts
+++ b/lrucache/build.gradle.kts
@@ -50,6 +50,10 @@ kotlin {
 
         val appleMain by creating {
             dependsOn(commonMain)
+
+            dependencies {
+                implementation("co.touchlab:stately-iso-collections:1.2.0")
+            }
         }
 
         val appleTest by creating {

--- a/lrucache/build.gradle.kts
+++ b/lrucache/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
 
     @Suppress("UNUSED_VARIABLE")
     sourceSets {
-        val jvmMain by getting {
+        val commonMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }

--- a/lrucache/src/appleMain/kotlin/com/mayakapps/lrucache/ConcurrentMutableMap.kt
+++ b/lrucache/src/appleMain/kotlin/com/mayakapps/lrucache/ConcurrentMutableMap.kt
@@ -1,0 +1,6 @@
+package com.mayakapps.lrucache
+
+import co.touchlab.stately.collections.IsoMutableMap
+
+internal actual class ConcurrentMutableMap<K : Any, V : Any> actual constructor() : MutableMap<K, V>,
+    IsoMutableMap<K, V>()

--- a/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/ConcurrentMutableMap.kt
+++ b/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/ConcurrentMutableMap.kt
@@ -1,0 +1,3 @@
+package com.mayakapps.lrucache
+
+internal expect class ConcurrentMutableMap<K : Any, V : Any>() : MutableMap<K, V>

--- a/lrucache/src/jvmMain/kotlin/com/mayakapps/lrucache/ConcurrentMutableMap.kt
+++ b/lrucache/src/jvmMain/kotlin/com/mayakapps/lrucache/ConcurrentMutableMap.kt
@@ -1,0 +1,11 @@
+package com.mayakapps.lrucache
+
+import java.util.concurrent.ConcurrentHashMap
+
+internal actual class ConcurrentMutableMap<K : Any, V : Any> actual constructor() : MutableMap<K, V>,
+    ConcurrentHashMap<K, V>(0, 0.75F, 1) {
+
+    override fun put(key: K, value: V): V? = super.put(key, value)
+
+    override fun remove(key: K): V? = super<ConcurrentHashMap>.remove(key)
+}


### PR DESCRIPTION
This adds all Apple targets and moves LruCache to commonMain.

This change required a multiplatform alternative to Java's `ConcurrentHashMap`. This was implemented using `ConcurrentHashMap` on JVM targets and [Stately](https://github.com/touchlab/Stately)'s `IsoMutableMap` on other platforms. I've chosen Java's built-in implementation as it is more trusted and consistent with Android's implementation. Maybe, I'll only change this behavior if there is performance issues with `ConcurrentHashMap`.

More targets maybe added to the library later after completing porting it to Kotlin Multiplatform.