### PR TITLE
Fix an issue causing old creation function to continue running after starting a new one

### DIFF
--- a/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/LruCache.kt
+++ b/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/LruCache.kt
@@ -163,6 +163,7 @@ class LruCache<K : Any, V : Any>(
             creationMap.remove(key)
         }
 
+        removeCreation(key, CODE_CREATION)
         creationMap[key] = deferred
         return deferred
     }


### PR DESCRIPTION
The expected behavior for put operations to replace any existing value or running creation function for the same key. This was working fine for put operations with a value but wasn't the case for put operations with a creation function. This lead to inconsistent behavior, and duplicate concurrent creation functions for same value.

The fix is adding the missing `removeFromCreation` call.