### PR TITLE
[Breaking] Change evicted value for entries removed by clear() to be false

### DIFF
--- a/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/LruCache.kt
+++ b/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/LruCache.kt
@@ -213,7 +213,14 @@ class LruCache<K : Any, V : Any>(
             removeCreation(key)
         }
 
-        trimToSize(size = -1) // -1 will evict 0-sized elements
+        mapMutex.withLock {
+            with(map.iterator()) {
+                forEach { (key, value) ->
+                    remove()
+                    onEntryRemoved(false, key, value, null)
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
As stated in the title, this changes `evicted` value passed to `onEntryRemoved` for entries removed by `clear()` to be false. This is different from `evictAll()` function from Android's implementation but this is the expected behavior. A scenario for this is that I'm implementing a wrapper around the cache that will automatically remove related objects when an entry is evicted using the trigger but will handle it when entries are explicitly removed.