### PR TITLE
Fix clear calls on non-JVM targets

### DIFF
--- a/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/LruCache.kt
+++ b/lrucache/src/commonMain/kotlin/com/mayakapps/lrucache/LruCache.kt
@@ -209,7 +209,7 @@ class LruCache<K : Any, V : Any>(
      * Clears the cache, calling [onEntryRemoved] on each removed entry.
      */
     suspend fun clear() {
-        for ((key, _) in creationMap) {
+        for (key in creationMap.keys) {
             removeCreation(key)
         }
 

--- a/lrucache/src/jvmMain/kotlin/com/mayakapps/lrucache/DiskLruCache.kt
+++ b/lrucache/src/jvmMain/kotlin/com/mayakapps/lrucache/DiskLruCache.kt
@@ -238,7 +238,7 @@ class DiskLruCache private constructor(
                     tempWriter.writeClean(key)
                 }
 
-                lruCache.creationMap.forEach { (key, _) -> tempWriter.writeDirty(key) }
+                lruCache.creationMap.forEachKey(1) { key -> tempWriter.writeDirty(key) }
             }
 
             if (journalFile.exists()) journalFile.renameToOrThrow(backupJournalFile, true)


### PR DESCRIPTION
These calls use forEach loop which accesses `entries` property of the map. The problem is that `IsoMutableMap` used on non-JVM platforms prohibits it as it exposes the non-concurrent underlying map. Since entries are not required at all it was easy fix.

The pull request also replaces similar usage in DiskLruCache in preparation for future port to other platforms.