### PR TITLE
Migrate to libs.versions.toml

### DIFF
--- a/disk-lru-cache/build.gradle.kts
+++ b/disk-lru-cache/build.gradle.kts
@@ -43,16 +43,16 @@ kotlin {
             dependencies {
                 implementation(project(":lru-cache"))
 
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+                implementation(libs.kotlinx.coroutines.core)
             }
         }
 
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("io.kotest:kotest-assertions-core:5.5.4")
+                implementation(libs.kotest.assertions)
 
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
 

--- a/disk-lru-cache/build.gradle.kts
+++ b/disk-lru-cache/build.gradle.kts
@@ -31,7 +31,6 @@ kotlin {
     iosSimulatorArm64(appleConfig)
 
     watchos(appleConfig)
-    watchosX86(appleConfig)
     watchosSimulatorArm64(appleConfig)
 
     tvos(appleConfig)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,14 @@
+[versions]
+kotlinx-coroutines = "1.6.4"
+
+stately = "1.2.0"
+
+kotest = "5.5.4"
+
+[libraries]
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+
+stately-isoCollections = { module = "co.touchlab:stately-iso-collections", version.ref = "stately" }
+
+kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/lru-cache/build.gradle.kts
+++ b/lru-cache/build.gradle.kts
@@ -72,16 +72,16 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+                implementation(libs.kotlinx.coroutines.core)
             }
         }
 
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("io.kotest:kotest-assertions-core:5.5.4")
+                implementation(libs.kotest.assertions)
 
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
 
@@ -89,7 +89,7 @@ kotlin {
             dependsOn(commonMain)
 
             dependencies {
-                implementation("co.touchlab:stately-iso-collections:1.2.0")
+                implementation(libs.stately.isoCollections)
             }
         }
 


### PR DESCRIPTION
This pull request also removes deprecated watchosX86 target from `:disk-lru-cache`