### PR TITLE
Increase Gradle VM max memory size to 3GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,9 @@ POM_LICENSE_DIST=repo
 POM_DEVELOPER_ID=MayakaApps
 POM_DEVELOPER_NAME=MayakaApps
 POM_DEVELOPER_URL=https://github.com/MayakaApps/
+
+#
+# Gradle VM
+#
+
+org.gradle.jvmargs=-Xmx3072m


### PR DESCRIPTION
This is done to fix Dokka documentation generation.