### PR TITLE
Fix Gradle Build

### DIFF
--- a/disk-lru-cache/build.gradle.kts
+++ b/disk-lru-cache/build.gradle.kts
@@ -9,11 +9,9 @@ plugins {
 
 kotlin {
     jvm {
-        compilations.all {
+        compilations.configureEach {
             kotlinOptions.jvmTarget = "1.8"
         }
-
-        withJava()
     }
 
     val appleConfig: KotlinNativeTarget.() -> Unit = {

--- a/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/BufferedInputStream.kt
+++ b/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/BufferedInputStream.kt
@@ -3,7 +3,7 @@ package com.mayakapps.lrucache.io
 
 internal actual class BufferedInputStream actual constructor(
     base: InputStream,
-    size: Int,
+    size: Int = 8192,
 ) : InputStream() {
 
     init {

--- a/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/BufferedOutputStream.kt
+++ b/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/BufferedOutputStream.kt
@@ -3,7 +3,7 @@ package com.mayakapps.lrucache.io
 
 internal actual class BufferedOutputStream actual constructor(
     private val base: OutputStream,
-    size: Int,
+    size: Int = 8192,
 ) : OutputStream() {
 
     private val buffer = ByteArray(size)

--- a/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/Exceptions.kt
+++ b/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/Exceptions.kt
@@ -1,6 +1,6 @@
 package com.mayakapps.lrucache.io
 
-internal actual open class IOException actual constructor(message: String?, cause: Throwable?) :
+internal actual open class IOException actual constructor(message: String? = null, cause: Throwable? = null) :
     Exception(message, cause)
 
-internal actual open class FileNotFoundException actual constructor(message: String?) : IOException(message)
+internal actual open class FileNotFoundException actual constructor(message: String? = null) : IOException(message)

--- a/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/FileOutputStream.kt
+++ b/disk-lru-cache/src/appleMain/kotlin/com/mayakapps/lrucache/io/FileOutputStream.kt
@@ -3,7 +3,7 @@ package com.mayakapps.lrucache.io
 import platform.Foundation.NSOutputStream
 import platform.Foundation.outputStreamToFileAtPath
 
-internal actual class FileOutputStream actual constructor(path: String, append: Boolean) :
+internal actual class FileOutputStream actual constructor(path: String, append: Boolean = true) :
     OutputStream(base = NSOutputStream.outputStreamToFileAtPath(path, append).apply { open() }) {
 
     override fun write(byte: Int) = defaultWrite(this, byte)

--- a/disk-lru-cache/src/appleTest/kotlin/com/mayakapps/lrucache/io/FileManagerTests.kt
+++ b/disk-lru-cache/src/appleTest/kotlin/com/mayakapps/lrucache/io/FileManagerTests.kt
@@ -85,24 +85,24 @@ class FileManagerTests {
         val subFile2 = NSString.pathWithComponents(listOf(subDir, "file2"))
         NSFileManager.defaultManager.createFileAtPath(subFile2, null, null)
 
-        DefaultFileManager.listContent(tempDirectory)!! shouldContainAll listOf(subFile1, subDir)
+        DefaultFileManager.listContents(tempDirectory)!! shouldContainAll listOf(subFile1, subDir)
     }
 
     @Test
     fun testListContentEmptyDirectory() {
         NSFileManager.defaultManager.createDirectoryAtPath(tempDirectory, true, null, null)
-        DefaultFileManager.listContent(tempDirectory)!! shouldHaveSize 0
+        DefaultFileManager.listContents(tempDirectory)!! shouldHaveSize 0
     }
 
     @Test
     fun testListContentExistentFile() {
         NSFileManager.defaultManager.createFileAtPath(tempFile, null, null)
-        DefaultFileManager.listContent(tempFile) shouldBe null
+        DefaultFileManager.listContents(tempFile) shouldBe null
     }
 
     @Test
     fun testListContentNonExistent() {
-        DefaultFileManager.listContent(tempFile) shouldBe null
+        DefaultFileManager.listContents(tempFile) shouldBe null
     }
 
     // 'DefaultFileManager.delete()' Tests

--- a/lru-cache/build.gradle.kts
+++ b/lru-cache/build.gradle.kts
@@ -9,11 +9,9 @@ plugins {
 
 kotlin {
     jvm {
-        compilations.all {
+        compilations.configureEach {
             kotlinOptions.jvmTarget = "1.8"
         }
-
-        withJava()
     }
 
     js(IR) {


### PR DESCRIPTION
This fixes gradle build of Kotlin/JVM by removing unnecessary `withJava()`. This pull request includes additional fixes for the I/O package of appleMain. These fixes are added as side changes as they are going to be replaced with Okio soon.